### PR TITLE
Fix email address Turtle IRI syntax

### DIFF
--- a/prof/rdf/prof.ttl
+++ b/prof/rdf/prof.ttl
@@ -16,7 +16,7 @@
                                 dct:creator [
                                     sdo:name "Nicholas J. Car" ;
                                     sdo:identifier <http://orcid.org/0000-0002-8742-7730> ;
-                                    sdo:email <nicholas.car@surroundaustralia.com> ;
+                                    sdo:email <mailto:nicholas.car@surroundaustralia.com> ;
                                     sdo:affiliation [
                                         sdo:name "SURROUND Australia Pty Ltd" ;
                                         sdo:url <https://surroundaustralia.com> ;
@@ -25,7 +25,7 @@
                                 [
                                     sdo:name "Rob Atkinson" ;
                                     sdo:identifier <http://orcid.org/0000-0002-7878-2693> ;
-                                    sdo:email <rob@metalinkage.com.au> ;
+                                    sdo:email <mailto:rob@metalinkage.com.au> ;
                                     sdo:affiliation [
                                         sdo:name "Open Geospatial Consortium" ;
                                         sdo:url <https://www.opengeospatial.org/> ;

--- a/prof/roles/resource_roles.ttl
+++ b/prof/roles/resource_roles.ttl
@@ -19,7 +19,7 @@
     dct:creator [
         sdo:name "Nicholas J. Car" ;
         sdo:identifier <http://orcid.org/0000-0002-8742-7730> ;
-        sdo:email <nicholas.car@surroundaustralia.com> ;
+        sdo:email <mailto:nicholas.car@surroundaustralia.com> ;
         sdo:affiliation [
         sdo:name "SURROUND Australia Pty Ltd" ;
         sdo:url <https://surroundaustralia.com> ;
@@ -28,7 +28,7 @@
     [
         sdo:name "Rob Atkinson" ;
         sdo:identifier <http://orcid.org/0000-0002-7878-2693> ;
-        sdo:email <rob@metalinkage.com.au> ;
+        sdo:email <mailto:rob@metalinkage.com.au> ;
         sdo:affiliation [
             sdo:name "Open Geospatial Consortium" ;
             sdo:url <https://www.opengeospatial.org/> ;


### PR DESCRIPTION
This PR is filed as part of my work with the SHACL 1.2 Profiling task force in the [Data Shapes working group](https://github.com/w3c/data-shapes).  The PR addresses a minor encoding matter that is blocking consumption of the PROF roles concept scheme.

`resource_roles.ttl` was not loading in a Turtle parser I tried due to a missing `mailto:` scheme on a non-compact node identifier.  Thmatter arose in `resource_roles.ttl`, and though the line-specific syntax is also present in `prof.ttl`, `prof.ttl` includes a `@base` directive that dispelled the syntax issue.  In both files, it appears to me that there is a missed `mailto:` scheme.

From trying out a few things with the [schema.org validator](https://validator.schema.org/)[^1], it appears these would be the minimally acceptable corrections (spelled as JSON-LD for reviewers' copy-paste convenience):

```json
{
  "@type": "https://schema.org/Person",
  "https://schema.org/email": {
    "@id": "mailto:bob@example.org",
    "@type": "https://schema.org/Text"
  }
}
```

```json
{
  "@type": "https://schema.org/Person",
  "https://schema.org/email": "bob@example.org"
}
```

From the OWL encoding in release 29.4, [`sdo:email` is an `owl:ObjectProperty`](https://github.com/schemaorg/schemaorg/blob/main/data/releases/29.4/schemaorg.owl#L16432-L16454).  The schema.org validator accepts `e a sdo:Text` when using the `p sdo:email e` style with e an IRI or blank node.

This PR is submitted fixing Turtle syntax while preserving the "thing or string" decision, but makes no further suggestions on extra annotations suggested by the schema.org validator.  I have no objections with the maintainers adding further patches and/or expanding scope before merging, or merging as-is.

[^1]: Disclaimer: Participation by NIST in the creation of the documentation of mentioned software is not intended to imply a recommendation or endorsement by the National Institute of Standards and Technology, nor is it intended to imply that any specific software is necessarily the best available for the purpose.