### PR TITLE
Draft catalog role for aggregated profile resources

### DIFF
--- a/prof/roles/resource_roles.ttl
+++ b/prof/roles/resource_roles.ttl
@@ -43,6 +43,16 @@
 
 This vocabulary is both a SKOS vocabulary and also a list of instances of the Profiles Vocabulary's [ResourceRole](www.w3.org/ns/dx/prof/ResourceRole) class."""@en .
 
+:catalog a owl:NamedIndividual,
+        skos:Concept,
+        prof:ResourceRole ;
+    skos:definition "A catalog that aggregates metadata about resources relevant to the profile, such as schemas, specifications, validators, or vocabularies"@en ;
+    skos:prefLabel "Catalog"@en ;
+    skos:altLabel "Catalogue"@en ;
+    skos:topConceptOf : ;
+    skos:scopeNote "Use this Role when you want to indicate an aggregation of resources relevant to a profile, such as schemas, specifications, validators, or vocabularies, especially where those resources are maintained externally to the profile itself. This role may be used alongside other roles when the resource is a catalog of resources of those kinds."@en ;
+.
+
 :constraints a owl:NamedIndividual,
         skos:Concept,
         prof:ResourceRole ;

--- a/prof/roles/resource_roles.ttl
+++ b/prof/roles/resource_roles.ttl
@@ -43,14 +43,13 @@
 
 This vocabulary is both a SKOS vocabulary and also a list of instances of the Profiles Vocabulary's [ResourceRole](www.w3.org/ns/dx/prof/ResourceRole) class."""@en .
 
-:catalog a owl:NamedIndividual,
+:manifest a owl:NamedIndividual,
         skos:Concept,
         prof:ResourceRole ;
     skos:definition "An aggregation resource that organizes metadata about resources relevant to a profile."@en ;
-    skos:prefLabel "Catalog"@en ;
-    skos:altLabel "Catalogue"@en ;
+    skos:prefLabel "Manifest"@en ;
     skos:topConceptOf : ;
-    skos:scopeNote "Use this Role when you want to indicate a resource that aggregates metadata about profile-relevant resources, such as schemas, specifications, validators, or vocabularies, especially where those resources are maintained externally to the profile itself. This role may be used for catalog-like resources, including but not limited to dcat:Catalog or schema:DataCatalog, and may be used alongside other roles where appropriate."@en ;
+    skos:scopeNote "Use this Role when you want to indicate a resource that aggregates metadata about profile-relevant resources, such as schemas, specifications, validators, or vocabularies, especially where those resources are maintained externally to the profile itself. This role may be used for catalog or manifest-like resources, and may be used alongside other roles where appropriate."@en ;
 .
 
 :constraints a owl:NamedIndividual,

--- a/prof/roles/resource_roles.ttl
+++ b/prof/roles/resource_roles.ttl
@@ -46,11 +46,11 @@ This vocabulary is both a SKOS vocabulary and also a list of instances of the Pr
 :catalog a owl:NamedIndividual,
         skos:Concept,
         prof:ResourceRole ;
-    skos:definition "A catalog that aggregates metadata about resources relevant to the profile, such as schemas, specifications, validators, or vocabularies"@en ;
+    skos:definition "An aggregation resource that organizes metadata about resources relevant to a profile."@en ;
     skos:prefLabel "Catalog"@en ;
     skos:altLabel "Catalogue"@en ;
     skos:topConceptOf : ;
-    skos:scopeNote "Use this Role when you want to indicate an aggregation of resources relevant to a profile, such as schemas, specifications, validators, or vocabularies, especially where those resources are maintained externally to the profile itself. This role may be used alongside other roles when the resource is a catalog of resources of those kinds."@en ;
+    skos:scopeNote "Use this Role when you want to indicate a resource that aggregates metadata about profile-relevant resources, such as schemas, specifications, validators, or vocabularies, especially where those resources are maintained externally to the profile itself. This role may be used for catalog-like resources, including but not limited to dcat:Catalog or schema:DataCatalog, and may be used alongside other roles where appropriate."@en ;
 .
 
 :constraints a owl:NamedIndividual,


### PR DESCRIPTION
Profiles often depend on evolving sets of resources such as vocabularies, validators, schemas, and specifications. In practice, these are not always maintained as stable one-by-one profile resource descriptors. Instead, they may be managed through a catalog that aggregates metadata about profile-relevant resources.

This role is intended to support that pattern, especially where resources are maintained externally to the profile itself.